### PR TITLE
[HotFix] Translate custom visual columns

### DIFF
--- a/wp-content/plugins/hurumap/index.php
+++ b/wp-content/plugins/hurumap/index.php
@@ -238,7 +238,7 @@ class HURUmap {
         switch ( $column ) {
             case 'visual_type' :
                 $post = get_post($post_id);
-                echo $post->post_excerpt;
+                echo wpm_translate_value($post->post_excerpt);
                 break;
             case 'in_topics' : {
                 $post = get_post($post_id);
@@ -250,7 +250,7 @@ class HURUmap {
                     <?php
                     foreach($in_topics as $in_topic ) {
                         ?>
-                         <li><?php echo $in_topic['title']; ?></li>
+                         <li><?php echo wpm_translate_value($in_topic['title']); ?></li>
                         <?php
                     }
                     ?>

--- a/wp-content/plugins/hurumap/index.php
+++ b/wp-content/plugins/hurumap/index.php
@@ -241,7 +241,7 @@ class HURUmap {
                 echo wpm_translate_value($post->post_excerpt);
                 break;
             case 'in_topics' : {
-                $post = get_post($post_id);
+                $post = wpm_translate_post(get_post($post_id));
                 $definition = json_decode($post->post_content, true);
                 if (is_array($definition['inTopics'])) {
                     $in_topics = $definition['inTopics'];
@@ -250,7 +250,7 @@ class HURUmap {
                     <?php
                     foreach($in_topics as $in_topic ) {
                         ?>
-                         <li><?php echo wpm_translate_value($in_topic['title']); ?></li>
+                         <li><?php echo $in_topic['title']; ?></li>
                         <?php
                     }
                     ?>

--- a/wp-content/plugins/hurumap/index.php
+++ b/wp-content/plugins/hurumap/index.php
@@ -237,11 +237,13 @@ class HURUmap {
     function hurumap_visual_column( $column, $post_id ) {
         switch ( $column ) {
             case 'visual_type' :
-                $post = get_post($post_id);
-                echo wpm_translate_value($post->post_excerpt);
+                $_post = get_post($post_id);
+                $post = get_posts(['numberposts' => 1, 'post_type' => $_post->post_type, 'post__in' => [$_post->ID], 'suppress_filters' => 0])[0];
+                echo $post->post_excerpt;
                 break;
             case 'in_topics' : {
-                $post = wpm_translate_post(get_post($post_id));
+                $_post = get_post($post_id);
+                $post = get_posts(['numberposts' => 1, 'post_type' => $_post->post_type, 'post__in' => [$_post->ID], 'suppress_filters' => 0])[0];
                 $definition = json_decode($post->post_content, true);
                 if (is_array($definition['inTopics'])) {
                     $in_topics = $definition['inTopics'];

--- a/wp-content/plugins/hurumap/utils.php
+++ b/wp-content/plugins/hurumap/utils.php
@@ -30,7 +30,7 @@ function relate_topics_to_pages() {
     ));
 
     foreach( $posts as $v_post ) {
-        $post = wpm_translate_post($v_post);
+        $post = get_posts(['numberposts' => 1,'post_type' => $v_post->post_type, 'post__in' => [$v_post->ID], 'suppress_filters' => 0])[0];
         if (!$post || ($post->post_excerpt != 'hurumap' && $post->post_excerpt != 'flourish')) {
             continue;
         }

--- a/wp-content/plugins/hurumap/utils.php
+++ b/wp-content/plugins/hurumap/utils.php
@@ -9,7 +9,7 @@ function topics_with_visual($visualId, $topics) {
             $slug = $categories[0]->slug;
         }
         if (preg_match("/chartId\":\"$visualId\"/i", $topic->post_content)) {
-            array_push($res, array('id' => $topic->ID, 'title' => $topic->post_title, 'countrySlug' => $slug ));
+            array_push($res, array('id' => $topic->ID, 'title' => wpm_translate_string($topic->post_title), 'countrySlug' => $slug ));
         }
     }
     return $res;
@@ -29,7 +29,8 @@ function relate_topics_to_pages() {
         'post_status'				=> array('publish')
     ));
 
-    foreach( $posts as $post ) {
+    foreach( $posts as $v_post ) {
+        $post = wpm_translate_post($v_post);
         if (!$post || ($post->post_excerpt != 'hurumap' && $post->post_excerpt != 'flourish')) {
             continue;
         }


### PR DESCRIPTION
## Description

- Getting post title using `get_post` returns a merged language content. This PR translates post while syncing visual to topics and on displaying on columns.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Desktop Screenshots

### Bug
![Screenshot from 2020-02-20 12-06-55](https://user-images.githubusercontent.com/7962097/74918414-1b0c7a80-53da-11ea-9417-0c96c3491b7d.png)

### Fix
![Screenshot from 2020-02-20 12-58-51](https://user-images.githubusercontent.com/7962097/74922881-f071f000-53e0-11ea-9f1c-6d47a48ea927.png)



## Mobile Screenshots



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
