### PR TITLE
[HotFix] Format post object result ->filter by language

### DIFF
--- a/wp-content/plugins/hurumap/acf.php
+++ b/wp-content/plugins/hurumap/acf.php
@@ -44,6 +44,30 @@ function acf_location_rule_match_page($match, $rule, $options, $field_group)
     return $match;
 }
 
+// //acf-to-rest-api uses get_field() function
+// //This filter is applied to the $value after it is loaded from the db and before it is returned to the template via functions such as get_field().
+add_filter( 'acf/format_value/type=relationship', 'acf_format_post_value', 20, 3 );
+add_filter( 'acf/format_value/type=post_object', 'acf_format_post_value', 20, 3 );
+
+function acf_format_post_value( $value, $post_id, $field ) {
+    if ( $field['return_format'] !== 'object' ) {
+        return $value;
+    }
+
+    if ( is_array( $value ) ) {
+        foreach( $value as $post ) {
+            $formatted[] = filter_by_lang( $post );
+        }
+    } else {
+        $formatted = filter_by_lang( $value );
+    }
+    return $formatted;
+};
+
+function filter_by_lang( $post ) {
+    return get_posts(['numberposts' => 1, 'post_type' => $post->post_type, 'post__in' => [$post->ID], 'suppress_filters' => 0])[0];
+}
+
 /**
  * Local JSON
  * https://www.advancedcustomfields.com/resources/local-json/


### PR DESCRIPTION
## Description

The plugin `acf-to-rest-api` uses the acf function `get_field()` to append acf results to wp-json result. However `get_field` loads its value straight from db which results to the unfiltered content. This PR used the filter `acf/format_value/type=relationship` &`acf/format_value/type=post_object` to filter the returned value of `get_field()`

https://www.advancedcustomfields.com/resources/acf-format_value/

 

Fixes [#171407493](https://www.pivotaltracker.com/story/show/171407493)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Desktop Screenshots

### Bug
<img width="1440" alt="Screen Shot 2020-02-21 at 6 57 50 AM" src="https://user-images.githubusercontent.com/7962097/75036196-597d6480-54c2-11ea-8c4d-bd28e25c8626.png">




## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
