### PR TITLE
ACF fields for analysis pages + language

### DIFF
--- a/wp-content/themes/hurumap/acf-json/group_5da86540dbf5a.json
+++ b/wp-content/themes/hurumap/acf-json/group_5da86540dbf5a.json
@@ -39,6 +39,63 @@
             "prepend": "",
             "append": "",
             "maxlength": ""
+        },
+        {
+            "key": "field_5e58dde68a4da",
+            "label": "Analysis share label",
+            "name": "analysis_share_label",
+            "type": "text",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "Share this analysis",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
+        },
+        {
+            "key": "field_5e58de058a4db",
+            "label": "analysis download label",
+            "name": "analysis_download_label",
+            "type": "text",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "Download this analysis",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
+        },
+        {
+            "key": "field_5e58de408a4dc",
+            "label": "Last Update label",
+            "name": "last_update_label",
+            "type": "text",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "Last Updated",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
         }
     ],
     "location": [
@@ -58,5 +115,5 @@
     "hide_on_screen": "",
     "active": 1,
     "description": "",
-    "modified": 1573045209
+    "modified": 1582882927
 }

--- a/wp-content/themes/hurumap/acf-json/group_5e58d9cb0e772.json
+++ b/wp-content/themes/hurumap/acf-json/group_5e58d9cb0e772.json
@@ -17,7 +17,7 @@
             },
             "choices": {
                 "en": "English",
-                "fr: French": "fr: French"
+                "fr": "French"
             },
             "default_value": [
                 "en"

--- a/wp-content/themes/hurumap/acf-json/group_5e58d9cb0e772.json
+++ b/wp-content/themes/hurumap/acf-json/group_5e58d9cb0e772.json
@@ -1,0 +1,51 @@
+{
+    "key": "group_5e58d9cb0e772",
+    "title": "Profile Language",
+    "fields": [
+        {
+            "key": "field_5e58d9e41e726",
+            "label": "Language",
+            "name": "language",
+            "type": "select",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "choices": {
+                "en": "English",
+                "fr: French": "fr: French"
+            },
+            "default_value": [
+                "en"
+            ],
+            "allow_null": 0,
+            "multiple": 0,
+            "ui": 0,
+            "return_format": "value",
+            "ajax": 0,
+            "placeholder": ""
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "post_type",
+                "operator": "==",
+                "value": "profile"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "normal",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": true,
+    "description": "",
+    "modified": 1582882927
+}


### PR DESCRIPTION
## Description

- Add acf field to define default language for each profile
- Add acf fields for labels in the analysis content page (share analysis, download this analysis, last updated)

Fixes [#171537155](https://www.pivotaltracker.com/story/show/171537155)

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## Desktop Screenshots
![Screenshot from 2020-02-28 12-45-55](https://user-images.githubusercontent.com/7962097/75538137-33f3dc00-5a29-11ea-9cc2-e4843650bef7.png)




## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
