### PR TITLE
Match charts theme with web

### DIFF
--- a/wp-content/plugins/hurumap/src/CardBlock/Edit.js
+++ b/wp-content/plugins/hurumap/src/CardBlock/Edit.js
@@ -4,7 +4,7 @@ import { Fragment } from '@wordpress/element';
 import { PanelBody, SelectControl, TextControl } from '@wordpress/components';
 import { InspectorControls } from '@wordpress/editor';
 
-import Card from '@codeforafrica/hurumap-ui/core/Card';
+import Card from '@codeforafrica/hurumap-ui/components/Card';
 
 import { select } from '@wordpress/data';
 import shortid from 'shortid';

--- a/wp-content/plugins/hurumap/src/ChartDefinition/ChartDefinition.js
+++ b/wp-content/plugins/hurumap/src/ChartDefinition/ChartDefinition.js
@@ -29,7 +29,14 @@ function ChartDefinition() {
       window.initial.chart &&
       visualType === window.initial.visualType
     ) {
-      return window.initial.chart;
+      return {
+        ...window.initial.chart,
+        typeProps:
+          Array.isArray(window.initial.chart.typeProps) ||
+          !window.initial.chart.typeProps
+            ? {}
+            : window.initial.chart.typeProps
+      };
     }
 
     if (formRef.current && formRef.current) {

--- a/wp-content/plugins/hurumap/src/Theme.js
+++ b/wp-content/plugins/hurumap/src/Theme.js
@@ -25,10 +25,26 @@ export default createTheme({
     group: {
       colorScale: COLOR_BREWER_DIVERGING
     },
+    line: {
+      offset: 70,
+      width: 350,
+      height: 350,
+      colorScale: ['#29a87c', '#a0d9b3', '#004494', '#4abc70'],
+      style: {
+        data: {
+          strokeWidth: 4
+        },
+        labels: {
+          fontFamily: FONT_FAMILY_TEXT,
+          fill: 'rgb(0,0,0)'
+        }
+      }
+    },
     bar: {
       width: 350,
       height: 350,
-      offset: 50,
+      barWidth: 30,
+      offset: 32,
       style: {
         data: {
           fill: COLOR_BREWER_DIVERGING[0]
@@ -39,16 +55,12 @@ export default createTheme({
         }
       }
     },
-    line: {
-      colorScale: ['#29a87c', '#a0d9b3', '#004494', '#4abc70'],
-      style: {
-        data: {
-          strokeWidth: 4
-        }
-      }
+    dependentAxis: {
+      fixLabelOverlap: true,
+      tickCount: 3
     },
     axis: {
-      labelWidth: 100,
+      labelWidth: 150,
       style: {
         tickLabels: {
           fontFamily: FONT_FAMILY_TEXT,
@@ -58,9 +70,7 @@ export default createTheme({
           fontFamily: FONT_FAMILY_TEXT,
           fill: 'rgb(0,0,0)'
         }
-      },
-      fixLabelOverlap: true,
-      tickCount: 4
+      }
     }
   },
   props: {


### PR DESCRIPTION
## Description

- [x] Ensure typeProps is always an Object. On production see `Revenue Allocation, November 2019 (₦ Billion)`. typeProps is somehow an array.

Before:
<img width="455" alt="Screen Shot 2020-03-03 at 6 41 18 AM" src="https://user-images.githubusercontent.com/4308339/75766846-584b0380-5d1c-11ea-86ab-516d8f2d7570.png">

After:
<img width="459" alt="Screen Shot 2020-03-03 at 7 03 03 AM" src="https://user-images.githubusercontent.com/4308339/75768711-6bab9e00-5d1f-11ea-8c0c-837d74590b0d.png">


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
